### PR TITLE
fixes for empty section header and footer heights

### DIFF
--- a/DTTableViewManager/DTTableViewController.m
+++ b/DTTableViewManager/DTTableViewController.m
@@ -363,7 +363,7 @@
     {
         if (![self headerModelForIndex:sectionNumber])
         {
-            return 0;
+            return CGFLOAT_MIN;
         }
         else
         {
@@ -378,7 +378,7 @@
     }
     else
     {
-        return 0;
+        return CGFLOAT_MIN;
     }
 }
 
@@ -389,7 +389,7 @@
     {
         if (![self footerModelForIndex:sectionNumber])
         {
-            return 0;
+            return CGFLOAT_MIN;
         }
         else
         {
@@ -404,7 +404,7 @@
     }
     else
     {
-        return 0;
+        return CGFLOAT_MIN;
     }
 }
 


### PR DESCRIPTION
For grouped table view for empty sections we should use CGFLOAT_MIN as sections header/footer height.

More info here:
http://stackoverflow.com/questions/2495936/grouped-uitableview-shows-blank-space-when-section-is-empty
http://stackoverflow.com/questions/19056428/how-to-hide-first-section-header-in-uitableview-grouped-style
