### PR TITLE
Fix Swift 2.3 compilation

### DIFF
--- a/Source/UIView+XibLoading.swift
+++ b/Source/UIView+XibLoading.swift
@@ -34,7 +34,9 @@ extension UIView
     /// - Returns: Loaded xib
     class func dt_loadFromXibNamed(xibName : String) -> UIView?
     {
-        let topLevelObjects = NSBundle(forClass: self).loadNibNamed(xibName, owner: nil, options: nil)
+        guard let topLevelObjects = NSBundle(forClass: self).loadNibNamed(xibName, owner: nil, options: nil) else {
+            return nil
+        }
         
         for object in topLevelObjects {
             if object.isKindOfClass(self) {


### PR DESCRIPTION
Explicitly unwrap optional, similar to the [Swift 3 fix](https://github.com/DenHeadless/DTTableViewManager/blob/bb6b3d6a408802b86a2a0e5ee4acc42da04d267b/Source/UIView%2BXibLoading.swift#L37-L39).